### PR TITLE
fix setup.py to handle case where pypandoc throws OSError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
     pypandoc.convert_file('README.md', 'rst', outputfile='README.rst')
     with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
         README = readme.read()
-except (ImportError, RuntimeError):
+except (ImportError, RuntimeError, OSError):
     README = short_description
 
 # import VERSION


### PR DESCRIPTION
this was required for running setup.py on my local machine (because pypandoc was installed but pandoc was not, and it throws an OSError not RuntimeError)